### PR TITLE
Update class.wp-publication-archive.php

### DIFF
--- a/lib/class.wp-publication-archive.php
+++ b/lib/class.wp-publication-archive.php
@@ -734,12 +734,16 @@ class WP_Publication_Archive {
 		 * @var string $author     Author slug to filter.
 		 * @var number $limit      Number of publications per page.
 		 * @var string $showas     Format to use when displaying publications.
+		 * @var string $sort       Which field to sort by, e.g. 'date' or 'name'
+		 * @var string $order      The sort order to use, e.g. 'asc' or 'desc'
 		 */
 		extract( shortcode_atts( array(
 		                              'categories' => '',
 		                              'author'     => '',
 		                              'limit'      => 10,
-		                              'showas'     => 'list'
+		                              'showas'     => 'list', 
+		                              'sort'	   => 'date', 
+		                              'order'	   => 'ASC'
 		                         ), $atts ) );
 
 		$limit = apply_filters( 'wpa-pubs_per_page', $limit ); // Ugly, deprecated filter.
@@ -753,13 +757,24 @@ class WP_Publication_Archive {
 			$offset = 0;
 		}
 
+		$sort = strtolower($sort);
+		$order = strtolower($order);
+		
+		// Defalt sort field and sort order
+		$sort_field = 'post_date';
+		$sort_order = 'DESC';
+		
+		// Check if alternative sort field and/or order have been provided
+		if ($sort == 'title') { $sort_field = 'post_title'; }
+		if ($order == 'asc') { $sort_order = 'ASC'; }
+		
 		// Get publications
 		$args = array(
 			'offset'      => $offset,
 			'numberposts' => $limit,
 			'post_type'   => 'publication',
-			'orderby'     => 'post_date',
-			'order'       => 'DESC',
+			'orderby'     => $sort_field,
+			'order'       => $sort_order,
 			'post_status' => 'publish'
 		);
 


### PR DESCRIPTION
Update too provide additional functionality to the shortcode.  This allows user to specificy a sort field and order, e.g.

`[wp-publication-archive categories="newsletters" sort="title" order="ASC" /]`

This gives all publications within the newsletters category sorted in ascending order by post title, i.e. alphabetical.

Note: This is the first time I've edited a public wordpress plugin and submitted a pull request, if I've done it incorrectly please let me know how to proceed in future.
